### PR TITLE
Update nyc-uber-ridesharing demo URL

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -198,7 +198,7 @@ with col1:
         "Interactive Data",
         "Make data apps to interactively explore data. In this case, check out NYC Uber pickups.",
         "images/Uber.png",
-        "https://share.streamlit.io/streamlit/demo-uber-nyc-pickups",
+        "https://share.streamlit.io/streamlit/demo-uber-nyc-pickups/main",
         "demo-uber-nyc-pickups",
     )
 with col2:


### PR DESCRIPTION
We've switched this app to use `main` 